### PR TITLE
Include required extra deps in the Makefile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,11 @@
 lib_LTLIBRARIES = OneVsOne.la
 
-OneVsOne_la_SOURCES = OneVsOne.cpp
+OneVsOne_la_SOURCES = \
+	UrlHandler.h \
+	UrlHandler.cpp \
+	INIParser.h \
+	INIParser.cpp \
+	OneVsOne.cpp
 OneVsOne_la_CPPFLAGS= -I$(top_srcdir)/include -I$(top_srcdir)/plugins/plugin_utils
 OneVsOne_la_LDFLAGS = -module -avoid-version -shared
 OneVsOne_la_LIBADD = $(top_builddir)/plugins/plugin_utils/libplugin_utils.la
@@ -11,7 +16,7 @@ AM_CXXFLAGS = $(CONF_CXXFLAGS)
 
 EXTRA_DIST = \
 	README.md \
-	LICENSE.md	
+	LICENSE.md
 
 MAINTAINERCLEANFILES =  \
 	Makefile.in


### PR DESCRIPTION
I believe the `Makefile.am` should have the other related files as part of the source otherwise you'll get undefined symbols at runtime.